### PR TITLE
Update sting_list.json location in README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -38,6 +38,6 @@ issues currently present. If you want some additional feature of some sort, by a
 the potential of adding it!
 
 Adding a new term to search for or replace is INCREDIBLY easy. Just add things to
-https://github.com/Valarissa/transgress/blob/master/lib/assets/string_list.json
+https://github.com/Valarissa/transgress/blob/master/lib/assets/javascripts/string_list.json
 and send the additions as a pull request. That's it. SUPER simple. With a few more additions to the JS code and some changes
 to the views, this project will be working as it's intended.


### PR DESCRIPTION
The string_list link in the README points to a 404. I guess the file was there but was then moved, this updates the README to point to the current location
