### PR TITLE
Encode http content as UTF-8 before regex matching

### DIFF
--- a/app/models/validator.rb
+++ b/app/models/validator.rb
@@ -1,8 +1,10 @@
 class Validator
   class << self
     def validate(document)
+      content = document.root.content
+      content.encode!('UTF-8', 'UTF-8', :invalid => :replace)
       regexes.each do |validator|
-        return true if document.root.content =~ validator
+        return true if content =~ validator
       end
 
       false


### PR DESCRIPTION
Fix https://github.com/Valarissa/transgress/issues/3 by encoding the response body as UTF-8. 

I googled around and found a [question on SO](http://stackoverflow.com/q/2982677/119768) that suggested  _"the net/http library doesn't have any encoding specific options and the stuff that comes in is basically not properly tagged."_. From that I made the assumption that we need to encode the body, and doing that does solve the issue I saw.
